### PR TITLE
Implement OpenAI transcription in service

### DIFF
--- a/src/services/transcriptionService.js
+++ b/src/services/transcriptionService.js
@@ -1,25 +1,31 @@
-const fs = require('fs');
-const path = require('path');
-const ffmpeg = require('fluent-ffmpeg');
-const tmp = require('tmp');
-const winston = require('winston');
+const fs = require("fs");
+const path = require("path");
+const ffmpeg = require("fluent-ffmpeg");
+const tmp = require("tmp");
+const winston = require("winston");
+const OpenAI = require("openai");
 
 const logger = winston.createLogger({
-  level: 'info',
+  level: "info",
   format: winston.format.combine(
     winston.format.timestamp(),
-    winston.format.json()
+    winston.format.json(),
   ),
-  transports: [new winston.transports.Console()]
+  transports: [new winston.transports.Console()],
+});
+
+// 初始化 OpenAI 客戶端
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY || "dummy-key",
 });
 
 // node-whisper 已移除，直接使用 OpenAI API
-logger.info('使用 OpenAI API 進行音頻轉錄');
+logger.info("使用 OpenAI API 進行音頻轉錄");
 
 // 針對 iPhone 錄音優化的參數
 const IPHONE_OPTIMIZED_CONFIG = {
   // 使用 base 模型以獲得更快速度
-  modelName: 'base',
+  modelName: "base",
   // 針對 iPhone 錄音的分塊策略
   chunkDuration: 12 * 60, // 12分鐘片段，平衡記憶體和準確度
   // 音檔預處理參數
@@ -29,16 +35,16 @@ const IPHONE_OPTIMIZED_CONFIG = {
     channels: 1,
     // 簡化濾波器，避免複雜濾鏡鏈問題
     filters: [
-      'highpass=f=80',    // 去除低頻雜訊
-      'lowpass=f=8000'    // 保留語音頻率範圍
-    ]
+      "highpass=f=80", // 去除低頻雜訊
+      "lowpass=f=8000", // 保留語音頻率範圍
+    ],
   },
   // OpenAI API 參數配置
   openaiOptions: {
-    language: 'zh',
+    language: "zh",
     temperature: 0.0,
-    response_format: 'text'
-  }
+    response_format: "text",
+  },
 };
 
 /**
@@ -51,10 +57,12 @@ async function getAudioInfo(filePath) {
         reject(err);
         return;
       }
-      
+
       const format = metadata.format;
-      const audioStream = metadata.streams.find(s => s.codec_type === 'audio');
-      
+      const audioStream = metadata.streams.find(
+        (s) => s.codec_type === "audio",
+      );
+
       resolve({
         duration: format.duration,
         sizeMB: format.size / (1024 * 1024),
@@ -63,7 +71,7 @@ async function getAudioInfo(filePath) {
         codec: audioStream?.codec_name,
         sampleRate: audioStream?.sample_rate,
         channels: audioStream?.channels,
-        isFromiPhone: detectiPhoneRecording(metadata)
+        isFromiPhone: detectiPhoneRecording(metadata),
       });
     });
   });
@@ -74,20 +82,22 @@ async function getAudioInfo(filePath) {
  */
 function detectiPhoneRecording(metadata) {
   const format = metadata.format;
-  const audioStream = metadata.streams.find(s => s.codec_type === 'audio');
-  
+  const audioStream = metadata.streams.find((s) => s.codec_type === "audio");
+
   // iPhone 錄音特徵
-  const isiPhoneFormat = format.format_name?.includes('mov') || 
-                        format.format_name?.includes('mp4') ||
-                        format.format_name?.includes('m4a');
-  
-  const isiPhoneCodec = audioStream?.codec_name === 'aac';
-  
+  const isiPhoneFormat =
+    format.format_name?.includes("mov") ||
+    format.format_name?.includes("mp4") ||
+    format.format_name?.includes("m4a");
+
+  const isiPhoneCodec = audioStream?.codec_name === "aac";
+
   const tags = format.tags || {};
-  const isiPhoneMetadata = tags.encoder?.includes('iPhone') || 
-                          tags.comment?.includes('iPhone') ||
-                          tags.creation_time; // iPhone 通常有創建時間
-  
+  const isiPhoneMetadata =
+    tags.encoder?.includes("iPhone") ||
+    tags.comment?.includes("iPhone") ||
+    tags.creation_time; // iPhone 通常有創建時間
+
   return isiPhoneFormat && isiPhoneCodec;
 }
 
@@ -97,19 +107,22 @@ function detectiPhoneRecording(metadata) {
 async function preprocessiPhoneAudio(inputPath, outputPath, audioInfo) {
   return new Promise((resolve, reject) => {
     logger.info(`iPhone 錄音預處理開始: ${inputPath}`);
-    
+
     // 設定超時機制 (5分鐘)
-    const timeout = setTimeout(() => {
-      logger.error('iPhone 錄音預處理超時');
-      reject(new Error('Audio preprocessing timeout'));
-    }, 5 * 60 * 1000);
-    
+    const timeout = setTimeout(
+      () => {
+        logger.error("iPhone 錄音預處理超時");
+        reject(new Error("Audio preprocessing timeout"));
+      },
+      5 * 60 * 1000,
+    );
+
     const config = IPHONE_OPTIMIZED_CONFIG.preprocessing;
-    
+
     // 根據原始音檔品質調整參數
     let finalBitrate = config.bitrate;
     let finalSampleRate = config.sampleRate;
-    
+
     // 如果原始音檔品質很高，保持較高設定
     if (audioInfo.bitrate > 256000) {
       finalBitrate = 128;
@@ -118,47 +131,53 @@ async function preprocessiPhoneAudio(inputPath, outputPath, audioInfo) {
       finalBitrate = 96;
       finalSampleRate = 24000;
     }
-    
+
     const ffmpegCommand = ffmpeg(inputPath)
-      .audioCodec('libmp3lame')
+      .audioCodec("libmp3lame")
       .audioBitrate(finalBitrate)
       .audioFrequency(finalSampleRate)
       .audioChannels(config.channels)
       .audioFilters(config.filters)
       .output(outputPath);
-    
+
     ffmpegCommand
-      .on('start', (commandLine) => {
+      .on("start", (commandLine) => {
         logger.info(`FFmpeg 處理開始: ${commandLine}`);
       })
-      .on('progress', (progress) => {
+      .on("progress", (progress) => {
         if (progress.percent) {
           logger.info(`預處理進度: ${Math.round(progress.percent)}%`);
         }
       })
-      .on('end', async () => {
+      .on("end", async () => {
         clearTimeout(timeout);
         try {
           const processedInfo = await getAudioInfo(outputPath);
-          
+
           logger.info(`iPhone 錄音預處理完成:`);
-          logger.info(`- 原始: ${audioInfo.sizeMB.toFixed(2)}MB, ${audioInfo.bitrate}bps`);
-          logger.info(`- 處理後: ${processedInfo.sizeMB.toFixed(2)}MB, ${processedInfo.bitrate}bps`);
-          logger.info(`- 壓縮率: ${((1 - processedInfo.sizeMB / audioInfo.sizeMB) * 100).toFixed(1)}%`);
-          
+          logger.info(
+            `- 原始: ${audioInfo.sizeMB.toFixed(2)}MB, ${audioInfo.bitrate}bps`,
+          );
+          logger.info(
+            `- 處理後: ${processedInfo.sizeMB.toFixed(2)}MB, ${processedInfo.bitrate}bps`,
+          );
+          logger.info(
+            `- 壓縮率: ${((1 - processedInfo.sizeMB / audioInfo.sizeMB) * 100).toFixed(1)}%`,
+          );
+
           resolve(outputPath);
         } catch (error) {
           logger.error(`獲取處理後音檔資訊失敗: ${error.message}`);
           resolve(outputPath);
         }
       })
-      .on('error', (err) => {
+      .on("error", (err) => {
         clearTimeout(timeout);
         logger.error(`iPhone 錄音預處理失敗: ${err.message}`);
-        
+
         // 如果是編解碼器問題，直接返回原始檔案
-        if (err.message.includes('codec') || err.message.includes('mp3')) {
-          logger.warn('編解碼器不可用，跳過預處理，使用原始檔案');
+        if (err.message.includes("codec") || err.message.includes("mp3")) {
+          logger.warn("編解碼器不可用，跳過預處理，使用原始檔案");
           resolve(inputPath);
         } else {
           reject(err);
@@ -174,21 +193,23 @@ async function preprocessiPhoneAudio(inputPath, outputPath, audioInfo) {
 async function smartSplitAudioForiPhone(inputPath, audioInfo) {
   const totalDuration = audioInfo.duration;
   const chunkDuration = IPHONE_OPTIMIZED_CONFIG.chunkDuration;
-  
+
   // iPhone 錄音品質高，可以使用較長片段
   if (totalDuration <= chunkDuration * 1.5) {
-    logger.info(`iPhone 錄音時長 ${(totalDuration/60).toFixed(1)} 分鐘，直接處理`);
+    logger.info(
+      `iPhone 錄音時長 ${(totalDuration / 60).toFixed(1)} 分鐘，直接處理`,
+    );
     return [inputPath];
   }
-  
+
   // 基於語音停頓的智能分割
   const pauseDetectionChunks = await splitByPauses(inputPath, chunkDuration);
-  
+
   if (pauseDetectionChunks.length > 0) {
     logger.info(`基於語音停頓分割為 ${pauseDetectionChunks.length} 個片段`);
     return pauseDetectionChunks;
   }
-  
+
   // 回到時間分割
   return await splitByTime(inputPath, chunkDuration);
 }
@@ -200,34 +221,41 @@ async function splitByPauses(inputPath, maxChunkDuration) {
   try {
     // 使用 ffmpeg 檢測靜音段
     const silenceDetection = await detectSilences(inputPath);
-    
+
     if (silenceDetection.length === 0) {
       return []; // 沒有檢測到靜音，使用時間分割
     }
-    
+
     const chunks = [];
     let currentStart = 0;
-    
+
     for (const silence of silenceDetection) {
       const chunkDuration = silence.start - currentStart;
-      
+
       if (chunkDuration >= maxChunkDuration) {
         // 在這個靜音點分割
-        const chunkPath = await extractChunk(inputPath, currentStart, silence.start);
+        const chunkPath = await extractChunk(
+          inputPath,
+          currentStart,
+          silence.start,
+        );
         chunks.push(chunkPath);
         currentStart = silence.end;
       }
     }
-    
+
     // 處理最後一個片段
     const audioInfo = await getAudioInfo(inputPath);
     if (currentStart < audioInfo.duration) {
-      const chunkPath = await extractChunk(inputPath, currentStart, audioInfo.duration);
+      const chunkPath = await extractChunk(
+        inputPath,
+        currentStart,
+        audioInfo.duration,
+      );
       chunks.push(chunkPath);
     }
-    
+
     return chunks;
-    
   } catch (error) {
     logger.warn(`基於停頓分割失敗，使用時間分割: ${error.message}`);
     return [];
@@ -240,16 +268,16 @@ async function splitByPauses(inputPath, maxChunkDuration) {
 async function detectSilences(inputPath) {
   return new Promise((resolve, reject) => {
     let silences = [];
-    
+
     ffmpeg(inputPath)
-      .audioFilters('silencedetect=n=-30dB:d=1.0') // 檢測1秒以上的靜音
-      .format('null')
-      .output('-')
-      .on('stderr', (stderrLine) => {
+      .audioFilters("silencedetect=n=-30dB:d=1.0") // 檢測1秒以上的靜音
+      .format("null")
+      .output("-")
+      .on("stderr", (stderrLine) => {
         // 解析 silencedetect 輸出
         const silenceStart = stderrLine.match(/silence_start: ([\d.]+)/);
         const silenceEnd = stderrLine.match(/silence_end: ([\d.]+)/);
-        
+
         if (silenceStart) {
           silences.push({ start: parseFloat(silenceStart[1]), end: null });
         }
@@ -257,12 +285,14 @@ async function detectSilences(inputPath) {
           silences[silences.length - 1].end = parseFloat(silenceEnd[1]);
         }
       })
-      .on('end', () => {
+      .on("end", () => {
         // 過濾出有效的靜音段
-        const validSilences = silences.filter(s => s.end !== null && (s.end - s.start) >= 1.0);
+        const validSilences = silences.filter(
+          (s) => s.end !== null && s.end - s.start >= 1.0,
+        );
         resolve(validSilences);
       })
-      .on('error', reject)
+      .on("error", reject)
       .run();
   });
 }
@@ -272,18 +302,18 @@ async function detectSilences(inputPath) {
  */
 async function extractChunk(inputPath, startTime, endTime) {
   const chunkPath = tmp.tmpNameSync({ postfix: `_chunk_${Date.now()}.mp3` });
-  
+
   return new Promise((resolve, reject) => {
     ffmpeg(inputPath)
       .seekInput(startTime)
       .duration(endTime - startTime)
-      .audioCodec('libmp3lame')
+      .audioCodec("libmp3lame")
       .audioBitrate(IPHONE_OPTIMIZED_CONFIG.preprocessing.bitrate)
       .audioFrequency(IPHONE_OPTIMIZED_CONFIG.preprocessing.sampleRate)
       .audioChannels(1)
       .output(chunkPath)
-      .on('end', () => resolve(chunkPath))
-      .on('error', reject)
+      .on("end", () => resolve(chunkPath))
+      .on("error", reject)
       .run();
   });
 }
@@ -295,70 +325,79 @@ async function splitByTime(inputPath, chunkDuration) {
   const audioInfo = await getAudioInfo(inputPath);
   const totalDuration = audioInfo.duration;
   const numChunks = Math.ceil(totalDuration / chunkDuration);
-  
+
   const chunks = [];
-  
+
   for (let i = 0; i < numChunks; i++) {
     const startTime = i * chunkDuration;
     const endTime = Math.min((i + 1) * chunkDuration, totalDuration);
-    
+
     const chunkPath = await extractChunk(inputPath, startTime, endTime);
     chunks.push(chunkPath);
-    
-    logger.info(`創建時間片段 ${i + 1}/${numChunks}: ${(startTime/60).toFixed(1)}-${(endTime/60).toFixed(1)} 分鐘`);
+
+    logger.info(
+      `創建時間片段 ${i + 1}/${numChunks}: ${(startTime / 60).toFixed(1)}-${(endTime / 60).toFixed(1)} 分鐘`,
+    );
   }
-  
+
   return chunks;
 }
 
 /**
  * 使用優化參數的 Faster-Whisper 轉錄
  */
-async function transcribeWithOptimizedWhisper(audioPath, isFromiPhone = false, progressCallback = null) {
+async function transcribeWithOptimizedWhisper(
+  audioPath,
+  isFromiPhone = false,
+  progressCallback = null,
+) {
   try {
-    logger.info(`開始轉錄 ${isFromiPhone ? 'iPhone 錄音' : '音檔'}: ${audioPath}`);
-    
+    logger.info(
+      `開始轉錄 ${isFromiPhone ? "iPhone 錄音" : "音檔"}: ${audioPath}`,
+    );
+
     const startTime = Date.now();
     const config = IPHONE_OPTIMIZED_CONFIG;
-    
+
     // 獲取音檔資訊
     const audioInfo = await getAudioInfo(audioPath);
-    
-    // 直接使用 OpenAI API，不使用本地 Whisper
-    logger.info('🔄 跳過本地 Whisper，直接使用 OpenAI API 轉錄');
-    
-    // 返回空結果，但保留音檔資訊
-    return {
-      text: '', 
-      quality: { score: 0, confidence: 0.0, details: 'Using OpenAI API' },
-      audioInfo: audioInfo
-    };
-    
+
+    // 使用 OpenAI API 進行轉錄
+    logger.info("🔄 使用 OpenAI API 轉錄");
+
+    const response = await openai.audio.transcriptions.create({
+      file: fs.createReadStream(audioPath),
+      model: process.env.OPENAI_TRANSCRIPTION_MODEL || "gpt-4o-mini-transcribe",
+      ...(config.openaiOptions || {}),
+    });
+
+    const transcript = response.text || "";
+
     const endTime = Date.now();
     const processingTime = (endTime - startTime) / 1000;
-    
+
     // 計算轉錄品質指標
     const quality = assessTranscriptionQuality(transcript);
-    
+
     if (progressCallback) {
-      progressCallback(100, '轉錄完成');
+      progressCallback(100, "轉錄完成");
     }
-    
+
     logger.info(`🎯 轉錄進度: 100% - 轉錄完成`);
     logger.info(`✅ 轉錄成功完成:`);
     logger.info(`- 處理時間: ${processingTime.toFixed(2)} 秒`);
     logger.info(`- 文字長度: ${transcript.length} 字元`);
     logger.info(`- 品質評分: ${quality.score}/100`);
     logger.info(`- 信心度: ${quality.confidence.toFixed(2)}`);
-    
+
     return {
       text: transcript.trim(),
-      processingTime: processingTime,
-      quality: quality
+      processingTime,
+      quality,
+      audioInfo,
     };
-    
   } catch (error) {
-    logger.error(`❌ Faster-Whisper 轉錄失敗: ${error.message}`);
+    logger.error(`❌ OpenAI 轉錄失敗: ${error.message}`);
     throw error;
   }
 }
@@ -369,36 +408,36 @@ async function transcribeWithOptimizedWhisper(audioPath, isFromiPhone = false, p
 function assessTranscriptionQuality(transcript) {
   let score = 100;
   let confidence = 1.0;
-  
+
   // 基本品質檢查
   if (transcript.length < 10) {
     score -= 50;
     confidence -= 0.5;
   }
-  
+
   // 檢查是否包含大量重複文字
   const repetitionRatio = checkRepetition(transcript);
   if (repetitionRatio > 0.3) {
     score -= 30;
     confidence -= 0.3;
   }
-  
+
   // 檢查標點符號合理性
   const punctuationScore = checkPunctuation(transcript);
   score += punctuationScore;
-  
+
   // 檢查中文字元比例
   const chineseRatio = checkChineseRatio(transcript);
   if (chineseRatio < 0.7) {
     score -= 20;
     confidence -= 0.2;
   }
-  
+
   return {
     score: Math.max(0, Math.min(100, score)),
     confidence: Math.max(0, Math.min(1, confidence)),
     repetitionRatio: repetitionRatio,
-    chineseRatio: chineseRatio
+    chineseRatio: chineseRatio,
   };
 }
 
@@ -408,12 +447,12 @@ function assessTranscriptionQuality(transcript) {
 function checkRepetition(text) {
   const words = text.split(/\s+/);
   const wordCount = {};
-  
-  words.forEach(word => {
+
+  words.forEach((word) => {
     wordCount[word] = (wordCount[word] || 0) + 1;
   });
-  
-  const repeatedWords = Object.values(wordCount).filter(count => count > 3);
+
+  const repeatedWords = Object.values(wordCount).filter((count) => count > 3);
   return repeatedWords.length / words.length;
 }
 
@@ -423,9 +462,9 @@ function checkRepetition(text) {
 function checkPunctuation(text) {
   const punctuationMarks = text.match(/[。！？，、；：]/g) || [];
   const expectedPunctuation = text.length / 50; // 估計應該有的標點數量
-  
+
   const ratio = punctuationMarks.length / expectedPunctuation;
-  
+
   if (ratio > 0.8 && ratio < 1.5) {
     return 10; // 標點符號合理
   } else if (ratio > 0.5 && ratio < 2.0) {
@@ -440,8 +479,8 @@ function checkPunctuation(text) {
  */
 function checkChineseRatio(text) {
   const chineseChars = text.match(/[\u4e00-\u9fff]/g) || [];
-  const totalChars = text.replace(/\s/g, '').length;
-  
+  const totalChars = text.replace(/\s/g, "").length;
+
   return totalChars > 0 ? chineseChars.length / totalChars : 0;
 }
 
@@ -450,81 +489,95 @@ function checkChineseRatio(text) {
  */
 async function transcribeAudio(inputPath) {
   const tempDir = tmp.dirSync({ unsafeCleanup: true });
-  const processedPath = path.join(tempDir.name, 'processed.mp3');
-  
+  const processedPath = path.join(tempDir.name, "processed.mp3");
+
   try {
     logger.info(`🚀 開始轉錄流程: ${inputPath}`);
     logger.info(`📊 整體進度: 0% - 初始化轉錄流程`);
-    
+
     // 1. 獲取音檔資訊
     logger.info(`📊 整體進度: 5% - 正在分析音檔資訊...`);
     const audioInfo = await getAudioInfo(inputPath);
     const isFromiPhone = audioInfo.isFromiPhone;
-    
+
     logger.info(`🎵 音檔資訊:`);
     logger.info(`- 格式: ${audioInfo.format} (${audioInfo.codec})`);
-    logger.info(`- 時長: ${(audioInfo.duration/60).toFixed(1)} 分鐘`);
+    logger.info(`- 時長: ${(audioInfo.duration / 60).toFixed(1)} 分鐘`);
     logger.info(`- 大小: ${audioInfo.sizeMB.toFixed(2)} MB`);
-    logger.info(`- iPhone 錄音: ${isFromiPhone ? '是' : '否'}`);
-    
+    logger.info(`- iPhone 錄音: ${isFromiPhone ? "是" : "否"}`);
+
     // 2. 預處理音檔
     logger.info(`📊 整體進度: 15% - 正在預處理音檔...`);
     await preprocessiPhoneAudio(inputPath, processedPath, audioInfo);
-    
+
     // 3. 智能分割
     logger.info(`📊 整體進度: 25% - 正在智能分割音檔...`);
     const processedInfo = await getAudioInfo(processedPath);
-    const chunkFiles = await smartSplitAudioForiPhone(processedPath, processedInfo);
-    
+    const chunkFiles = await smartSplitAudioForiPhone(
+      processedPath,
+      processedInfo,
+    );
+
     logger.info(`🔄 分割結果: ${chunkFiles.length} 個片段`);
-    
+
     // 4. 轉錄處理
     logger.info(`📊 整體進度: 30% - 開始轉錄處理...`);
-    let finalTranscript = '';
+    let finalTranscript = "";
     let totalQuality = { score: 0, confidence: 0 };
-    
+
     if (chunkFiles.length === 1) {
       // 單個檔案直接轉錄
       logger.info(`📊 整體進度: 35% - 單檔轉錄模式`);
-      
+
       const progressCallback = (percent, message) => {
-        const overallProgress = 35 + (percent * 0.55); // 35% 到 90%
+        const overallProgress = 35 + percent * 0.55; // 35% 到 90%
         logger.info(`📊 整體進度: ${overallProgress.toFixed(0)}% - ${message}`);
       };
-      
-      const result = await transcribeWithOptimizedWhisper(chunkFiles[0], isFromiPhone, progressCallback);
+
+      const result = await transcribeWithOptimizedWhisper(
+        chunkFiles[0],
+        isFromiPhone,
+        progressCallback,
+      );
       finalTranscript = result.text;
       totalQuality = result.quality;
     } else {
       // 多個片段批次處理
-      logger.info(`📊 整體進度: 35% - 多檔批次轉錄模式 (${chunkFiles.length} 個片段)`);
-      
-      const results = await processAudioChunks(chunkFiles, isFromiPhone, (current, total) => {
-        const chunkProgress = 35 + ((current / total) * 55); // 35% 到 90%
-        logger.info(`📊 整體進度: ${chunkProgress.toFixed(0)}% - 正在處理片段 ${current}/${total}`);
-      });
-      
+      logger.info(
+        `📊 整體進度: 35% - 多檔批次轉錄模式 (${chunkFiles.length} 個片段)`,
+      );
+
+      const results = await processAudioChunks(
+        chunkFiles,
+        isFromiPhone,
+        (current, total) => {
+          const chunkProgress = 35 + (current / total) * 55; // 35% 到 90%
+          logger.info(
+            `📊 整體進度: ${chunkProgress.toFixed(0)}% - 正在處理片段 ${current}/${total}`,
+          );
+        },
+      );
+
       finalTranscript = results.text;
       totalQuality = results.quality;
     }
-    
+
     // 5. 後處理
     logger.info(`📊 整體進度: 95% - 正在後處理轉錄結果...`);
     const cleanedTranscript = cleanupTranscript(finalTranscript);
-    
+
     logger.info(`📊 整體進度: 100% - 轉錄流程完成！`);
     logger.info(`🎉 轉錄流程成功完成:`);
     logger.info(`- 最終文字長度: ${cleanedTranscript.length} 字元`);
     logger.info(`- 整體品質評分: ${totalQuality.score}/100`);
     logger.info(`- 整體信心度: ${totalQuality.confidence.toFixed(2)}`);
-    
+
     return {
       transcript: cleanedTranscript,
       quality: totalQuality,
       audioInfo: audioInfo,
-      processedFilePath: processedPath  // 提供預處理後的檔案路徑給 OpenAI API 使用
+      processedFilePath: processedPath, // 提供預處理後的檔案路徑給 OpenAI API 使用
     };
-    
   } catch (error) {
     logger.error(`❌ 轉錄流程失敗: ${error.message}`);
     throw error;
@@ -538,29 +591,38 @@ async function transcribeAudio(inputPath) {
 /**
  * 處理音檔分塊
  */
-async function processAudioChunks(chunkFiles, isFromiPhone, progressCallback = null) {
+async function processAudioChunks(
+  chunkFiles,
+  isFromiPhone,
+  progressCallback = null,
+) {
   const results = [];
   let totalScore = 0;
   let totalConfidence = 0;
-  
+
   for (let i = 0; i < chunkFiles.length; i++) {
     const chunkPath = chunkFiles[i];
-    
+
     try {
       logger.info(`🎯 處理片段 ${i + 1}/${chunkFiles.length}`);
-      
+
       // 回報進度
       if (progressCallback) {
         progressCallback(i + 1, chunkFiles.length);
       }
-      
+
       const chunkProgressCallback = (percent, message) => {
-        const chunkPercent = (i / chunkFiles.length) * 100 + (percent / chunkFiles.length);
+        const chunkPercent =
+          (i / chunkFiles.length) * 100 + percent / chunkFiles.length;
         logger.info(`📊 片段 ${i + 1} 進度: ${percent}% - ${message}`);
       };
-      
-      const result = await transcribeWithOptimizedWhisper(chunkPath, isFromiPhone, chunkProgressCallback);
-      
+
+      const result = await transcribeWithOptimizedWhisper(
+        chunkPath,
+        isFromiPhone,
+        chunkProgressCallback,
+      );
+
       if (result.text && result.text.length > 0) {
         results.push(result.text);
         totalScore += result.quality.score;
@@ -570,7 +632,6 @@ async function processAudioChunks(chunkFiles, isFromiPhone, progressCallback = n
         logger.warn(`⚠️ 片段 ${i + 1} 轉錄結果為空`);
         results.push(`[片段 ${i + 1} 無法轉錄]`);
       }
-      
     } catch (error) {
       logger.error(`❌ 轉錄片段 ${i + 1} 失敗: ${error.message}`);
       results.push(`[片段 ${i + 1} 轉錄失敗: ${error.message}]`);
@@ -585,18 +646,19 @@ async function processAudioChunks(chunkFiles, isFromiPhone, progressCallback = n
       }
     }
   }
-  
+
   const avgScore = results.length > 0 ? totalScore / results.length : 0;
-  const avgConfidence = results.length > 0 ? totalConfidence / results.length : 0;
-  
+  const avgConfidence =
+    results.length > 0 ? totalConfidence / results.length : 0;
+
   logger.info(`🎉 所有片段處理完成: ${results.length} 個片段`);
-  
+
   return {
-    text: results.join('\n\n'),
+    text: results.join("\n\n"),
     quality: {
       score: avgScore,
-      confidence: avgConfidence
-    }
+      confidence: avgConfidence,
+    },
   };
 }
 
@@ -605,10 +667,10 @@ async function processAudioChunks(chunkFiles, isFromiPhone, progressCallback = n
  */
 function cleanupTranscript(transcript) {
   return transcript
-    .replace(/\[\s*\]/g, '') // 移除空白標記
-    .replace(/\s+/g, ' ') // 合併多個空白
-    .replace(/\n\s*\n\s*\n/g, '\n\n') // 合併多個換行
-    .replace(/([。！？])\s*([。！？])/g, '$1$2') // 合併重複標點
+    .replace(/\[\s*\]/g, "") // 移除空白標記
+    .replace(/\s+/g, " ") // 合併多個空白
+    .replace(/\n\s*\n\s*\n/g, "\n\n") // 合併多個換行
+    .replace(/([。！？])\s*([。！？])/g, "$1$2") // 合併重複標點
     .trim();
 }
 
@@ -616,5 +678,5 @@ module.exports = {
   transcribeAudio,
   getAudioInfo,
   preprocessiPhoneAudio,
-  assessTranscriptionQuality
+  assessTranscriptionQuality,
 };


### PR DESCRIPTION
## Summary
- Initialize OpenAI client in transcription service
- Replace placeholder return with actual OpenAI transcription call and retain quality evaluation

## Testing
- `npm test` (no tests found)
- `npm run lint` (ESLint couldn't find a configuration file)
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688c8894ac1c8320b511fe0a105e0d81