### PR TITLE
Use response.text for OpenAI transcription

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -352,7 +352,7 @@ async function transcribeWithOpenAI(localFilePath) {
         temperature: 0.0
       });
       
-      transcript = response.trim();
+      transcript = response.text.trim();
       totalProcessingTime = (Date.now() - startTime) / 1000;
       
     } else {
@@ -392,7 +392,7 @@ async function transcribeWithOpenAI(localFilePath) {
             temperature: 0.0
           });
           
-          const chunkTranscript = response.trim();
+          const chunkTranscript = response.text.trim();
           transcripts.push(chunkTranscript);
           
           logger.info(`✅ 分片 ${i + 1} 轉錄完成: ${chunkTranscript.length} 字元`);


### PR DESCRIPTION
## Summary
- switch to `response.text.trim()` for OpenAI audio transcription results
- apply the same `response.text` handling when processing audio chunks

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688c87b807488320b76e3abe7272f32c